### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/LOZY_FLASK/Lozi DemoP/LOZI-FINAL (5)/LOZI-FINAL/LOZI/app.py
+++ b/LOZY_FLASK/Lozi DemoP/LOZI-FINAL (5)/LOZI-FINAL/LOZI/app.py
@@ -113,5 +113,8 @@ def vehicleStorage():
 def warehouseStorage():
     return render_template('warhouseStorage.html')
 
+import os
+
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/yuktadandevapq/demo/security/code-scanning/1](https://github.com/yuktadandevapq/demo/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using environment variables to control the debug mode. This way, we can set the debug mode to `True` only in a development environment and `False` in a production environment.

We will modify the `app.run()` call to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode. This change will be made in the `LOZY_FLASK/Lozi DemoP/LOZI-FINAL (5)/LOZI-FINAL/LOZI/app.py` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
